### PR TITLE
fixed: qa_transmitter imports work for ctest etc

### DIFF
--- a/lib/gfdm_utils.cc
+++ b/lib/gfdm_utils.cc
@@ -73,8 +73,8 @@ namespace gr {
     void
     rrc_filter_sparse::get_taps(std::vector<gr_complex> &out)
     {
+      out.resize(d_filter_taps.size());
       std::memcpy(&out[0],&d_filter_taps[0],sizeof(gr_complex)*d_filter_taps.size());
-
     };
 
   } /* namespace gfdm */

--- a/lib/modulator_cc_impl.h
+++ b/lib/modulator_cc_impl.h
@@ -41,7 +41,7 @@ namespace gr {
        int d_fft_len;
        int d_sync_fft_len;
        std::string d_len_tag_key;
-       std::vector<gr_complex> d_filter_taps;
+       gr_complex* d_filter_taps;
        fft::fft_complex *d_sc_fft;
        gr_complex * d_sc_fft_in;
        gr_complex * d_sc_fft_out;
@@ -51,7 +51,10 @@ namespace gr {
        fft::fft_complex *d_out_ifft;
        gr_complex * d_out_ifft_in;
        gr_complex * d_out_ifft_out;
+
+        gr_complex* d_sc_tmp;
       // Nothing to declare in this block.
+      void modulate_gfdm_frame(gr_complex *out, const gr_complex *in);
 
      protected:
       int calculate_output_stream_length(const gr_vector_int &ninput_items);

--- a/python/qa_transmitter_cvc.py
+++ b/python/qa_transmitter_cvc.py
@@ -26,46 +26,47 @@ import gfdm_swig as gfdm
 from pygfdm.modulation import gfdm_tx_fft2
 
 
-class qa_transmitter_cvc (gr_unittest.TestCase):
+class qa_transmitter_cvc(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
 
-    def setUp (self):
-        self.tb = gr.top_block ()
-
-    def tearDiown (self):
+    def tearDown(self):
         self.tb = None
 
-    def test_001_t (self):
+    def test_001_t(self):
         # set up fg
         nsubcarrier = 8
         ntimeslots = 16
         filter_width = 2
         filter_alpha = 0.35
-        src_data = np.array([np.complex(np.random.choice([-1, 1]), np.random.choice([-1, 1])) for i in xrange(nsubcarrier*ntimeslots)])
-        expected_result = gfdm_tx_fft2(src_data,'rrc',filter_alpha,ntimeslots,nsubcarrier,filter_width,1)
+        src_data = np.array([np.complex(np.random.choice([-1, 1]), np.random.choice([-1, 1])) for i in
+                             xrange(nsubcarrier * ntimeslots)])
+        expected_result = gfdm_tx_fft2(src_data, 'rrc', filter_alpha, ntimeslots, nsubcarrier, filter_width, 1)
         src = blocks.vector_source_c(src_data)
-        tm = gfdm.transmitter_cvc(nsubcarrier,ntimeslots,filter_width,filter_alpha)
-        dst = blocks.vector_sink_c(vlen=nsubcarrier*ntimeslots)
-        self.tb.connect(src,tm)
-        self.tb.connect(tm,dst)
-        self.tb.run ()
+        tm = gfdm.transmitter_cvc(nsubcarrier, ntimeslots, filter_width, filter_alpha)
+        dst = blocks.vector_sink_c(vlen=nsubcarrier * ntimeslots)
+        self.tb.connect(src, tm)
+        self.tb.connect(tm, dst)
+        self.tb.run()
         # check data
         result_data = dst.data()
         self.assertComplexTuplesAlmostEqual(expected_result, result_data, 2)
 
-    def test_002_t (self):
+    def test_002_t(self):
         # set up fg
         nsubcarrier = 64
         ntimeslots = 32
         filter_width = 2
         filter_alpha = 0.35
-        src_data = np.array([np.complex(np.random.choice([-1, 1]), np.random.choice([-1, 1])) for i in xrange(nsubcarrier*ntimeslots)])
-        expected_result = gfdm_tx_fft2(src_data,'rrc',filter_alpha,ntimeslots,nsubcarrier,filter_width,1)
+        src_data = np.array([np.complex(np.random.choice([-1, 1]), np.random.choice([-1, 1])) for i in
+                             xrange(nsubcarrier * ntimeslots)])
+        expected_result = gfdm_tx_fft2(src_data, 'rrc', filter_alpha, ntimeslots, nsubcarrier, filter_width, 1)
         src = blocks.vector_source_c(src_data)
-        tm = gfdm.transmitter_cvc(nsubcarrier,ntimeslots,filter_width,filter_alpha)
-        dst = blocks.vector_sink_c(vlen=nsubcarrier*ntimeslots)
-        self.tb.connect(src,tm)
-        self.tb.connect(tm,dst)
-        self.tb.run ()
+        tm = gfdm.transmitter_cvc(nsubcarrier, ntimeslots, filter_width, filter_alpha)
+        dst = blocks.vector_sink_c(vlen=nsubcarrier * ntimeslots)
+        self.tb.connect(src, tm)
+        self.tb.connect(tm, dst)
+        self.tb.run()
         # check data
         result_data = dst.data()
         self.assertComplexTuplesAlmostEqual(expected_result, result_data, 3)

--- a/python/qa_transmitter_cvc.py
+++ b/python/qa_transmitter_cvc.py
@@ -22,8 +22,8 @@
 from gnuradio import gr, gr_unittest
 from gnuradio import blocks
 import numpy as np
-import gfdm
-import gfdm_swig as gfdms
+import gfdm_swig as gfdm
+from pygfdm.modulation import gfdm_tx_fft2
 
 
 class qa_transmitter_cvc (gr_unittest.TestCase):
@@ -41,9 +41,9 @@ class qa_transmitter_cvc (gr_unittest.TestCase):
         filter_width = 2
         filter_alpha = 0.35
         src_data = np.array([np.complex(np.random.choice([-1, 1]), np.random.choice([-1, 1])) for i in xrange(nsubcarrier*ntimeslots)])
-        expected_result = gfdm.modulation.gfdm_tx_fft2(src_data,'rrc',filter_alpha,ntimeslots,nsubcarrier,filter_width,1)
+        expected_result = gfdm_tx_fft2(src_data,'rrc',filter_alpha,ntimeslots,nsubcarrier,filter_width,1)
         src = blocks.vector_source_c(src_data)
-        tm = gfdms.transmitter_cvc(nsubcarrier,ntimeslots,filter_width,filter_alpha)
+        tm = gfdm.transmitter_cvc(nsubcarrier,ntimeslots,filter_width,filter_alpha)
         dst = blocks.vector_sink_c(vlen=nsubcarrier*ntimeslots)
         self.tb.connect(src,tm)
         self.tb.connect(tm,dst)
@@ -59,9 +59,9 @@ class qa_transmitter_cvc (gr_unittest.TestCase):
         filter_width = 2
         filter_alpha = 0.35
         src_data = np.array([np.complex(np.random.choice([-1, 1]), np.random.choice([-1, 1])) for i in xrange(nsubcarrier*ntimeslots)])
-        expected_result = gfdm.modulation.gfdm_tx_fft2(src_data,'rrc',filter_alpha,ntimeslots,nsubcarrier,filter_width,1)
+        expected_result = gfdm_tx_fft2(src_data,'rrc',filter_alpha,ntimeslots,nsubcarrier,filter_width,1)
         src = blocks.vector_source_c(src_data)
-        tm = gfdms.transmitter_cvc(nsubcarrier,ntimeslots,filter_width,filter_alpha)
+        tm = gfdm.transmitter_cvc(nsubcarrier,ntimeslots,filter_width,filter_alpha)
         dst = blocks.vector_sink_c(vlen=nsubcarrier*ntimeslots)
         self.tb.connect(src,tm)
         self.tb.connect(tm,dst)


### PR DESCRIPTION
Had a look at this QA file. Fixed imports. Should work with 'ctest' or similar again.
